### PR TITLE
Made Linux and Windows versions use https instead of ssh

### DIFF
--- a/from-template.bat
+++ b/from-template.bat
@@ -7,7 +7,7 @@ echo %REPO%
 
 echo %cd%
 
-call git clone "git@github.com:racket-templates/%REPO%.git" %DEST%
+call git clone "https://github.com/racket-templates/%REPO%.git" %DEST%
 
 if not exist %DEST% goto :clone_failed
 

--- a/from-template.sh
+++ b/from-template.sh
@@ -3,7 +3,7 @@
 echo "$1"
 pwd
 
-git clone "git@github.com:racket-templates/$1.git" $2
+git clone "https://github.com/racket-templates/$1.git" $2
 if [ -d "$2" ]; then
 	cd "$2"
 	rm -rf .git


### PR DESCRIPTION
Changed this to use HTTPS instead of SSH since SSH will require that the user has an SSH key set up.

@spdegabrielle how's this? This way mac and linux can use the same script. 