### PR TITLE
readme: delete link to template-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Contibutions to both this tool and the collection of templates is welcome.
 Contribute to this project by submitting a pull request or reporting an issue. Discussion on [Racket Users mailing list](https://groups.google.com/forum/#!forum/racket-users/join) ([google group](https://groups.google.com/forum/#!forum/racket-users)),
 [#racket IRC on freenode.net](https://botbot.me/freenode/racket/) or [Racket Slack](https://racket-slack.herokuapp.com/).
 
-Comtribute a new template by using the template at https://github.com/racket-templates/template-template 
-
 # License
 
 This package is free software, see [LICENSE](https://github.com/nixin72/from-template/blob/master/LICENSE) for more details.


### PR DESCRIPTION
The repo `racket-templates/template-template` does not exist